### PR TITLE
Spec can set non-default deployment

### DIFF
--- a/config/test_config.rb
+++ b/config/test_config.rb
@@ -6,8 +6,8 @@ class TestConfig < Config
 
   attr_reader :deployment, :driver
 
-  def initialize
-    @deployment = Config.deployment
+  def initialize(deployment=nil)
+    @deployment = deployment || Config.deployment
   end
 
   def set_driver(driver)

--- a/pages/core/core_create_new_page.rb
+++ b/pages/core/core_create_new_page.rb
@@ -12,8 +12,8 @@ class CoreCreateNewPage
   def acquisition_link; {:id => 'acquisition'} end
   def exhibition_link; {:id => 'exhibition'} end
   def use_of_collections_link; {:id => 'uoc'} end
-  def authority_org_local_link; {:id => 'organization/local'} end
-  def authority_org_ulan_link; {:id => 'organization/ulan'} end
+  def authority_org_local_link; {:xpath => '//a[@id="organization/local"]'} end
+  def authority_org_ulan_link; {:xpath => '//a[@id="organization/ulan"]'} end
 
   # Loads the Create New page with a given base URL
   # @param [String] base_url


### PR DESCRIPTION
Also, safaridriver and geckodriver don't like slashes when finding elements by id.